### PR TITLE
Setup Next.js skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/components/SynthesisCard.tsx
+++ b/components/SynthesisCard.tsx
@@ -1,0 +1,11 @@
+interface Props {
+  text: string | string[] | undefined;
+}
+
+export default function SynthesisCard({ text }: Props) {
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '1rem', marginTop: '1rem' }}>
+      {text}
+    </div>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "nexus-cross-ai",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "typescript": "latest"
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Nexus Cross AI</h1>
+      <Link href="/prompt">Ir para o prompt</Link>
+    </div>
+  );
+}

--- a/pages/prompt.tsx
+++ b/pages/prompt.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function PromptPage() {
+  const [prompt, setPrompt] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    router.push({
+      pathname: '/result',
+      query: { prompt },
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Envie seu prompt</h2>
+      <textarea
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        rows={4}
+        cols={40}
+      />
+      <button type="submit">Enviar</button>
+    </form>
+  );
+}

--- a/pages/result.tsx
+++ b/pages/result.tsx
@@ -1,0 +1,14 @@
+import { useRouter } from 'next/router';
+import SynthesisCard from '../components/SynthesisCard';
+
+export default function ResultPage() {
+  const router = useRouter();
+  const { prompt } = router.query;
+
+  return (
+    <div>
+      <h2>Resultado</h2>
+      <SynthesisCard text={`Resposta para: ${prompt}`} />
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Next.js skeleton with TypeScript config
- create basic pages and a simple component
- provide example environment file and gitignore

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run dev` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844215b524483239e644e49e0b869ba