### PR TITLE
Add model selector and history UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Nexus Cross AI
 
 This is a minimal prototype for the Nexus Cross AI project using Next.js, Firebase and the OpenAI API.
+It now includes a very small usage counter and a dropdown to choose between AI models.
+Only the OpenAI option is fully functional – the others return placeholder text.
+Each authenticated user can see their request history stored in Firestore.
 
 ## Development
 

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -4,14 +4,29 @@ import { OpenAI } from 'openai'
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || '' })
 
 export async function POST(req: NextRequest) {
-  const { prompt } = await req.json()
+  const { prompt, model } = await req.json()
   if (!prompt) {
     return NextResponse.json({ error: 'No prompt provided' }, { status: 400 })
   }
-  const chat = await openai.chat.completions.create({
-    messages: [{ role: 'user', content: prompt }],
-    model: 'gpt-4o',
-  })
-  const result = chat.choices[0].message.content
-  return NextResponse.json({ result })
+
+  const selected = model || 'openai'
+
+  if (selected === 'openai') {
+    const chat = await openai.chat.completions.create({
+      messages: [{ role: 'user', content: prompt }],
+      model: 'gpt-4o',
+    })
+    const result = chat.choices[0].message.content
+    return NextResponse.json({ result })
+  }
+
+  if (selected === 'claude') {
+    return NextResponse.json({ result: 'Claude integration coming soon.' })
+  }
+
+  if (selected === 'gemini') {
+    return NextResponse.json({ result: 'Gemini integration coming soon.' })
+  }
+
+  return NextResponse.json({ error: 'Unknown model' }, { status: 400 })
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useState } from 'react'
-import { signInAnonymously } from 'firebase/auth'
-import { collection, addDoc } from 'firebase/firestore'
+import { useState, useEffect } from 'react'
+import { signInAnonymously, User } from 'firebase/auth'
+import { collection, addDoc, getDocs, query, where, orderBy } from 'firebase/firestore'
 import { initFirebase } from '../firebaseConfig'
 
 const { auth, db } = initFirebase()
@@ -11,31 +11,104 @@ export default function Home() {
   const [prompt, setPrompt] = useState('')
   const [loading, setLoading] = useState(false)
   const [response, setResponse] = useState('')
+  const [model, setModel] = useState('openai')
+  const [history, setHistory] = useState<any[]>([])
+  const [user, setUser] = useState<User | null>(null)
+  const [usage, setUsage] = useState(0)
+  const usageLimit = 5
+
+  useEffect(() => {
+    const signInAndLoad = async () => {
+      const cred = await signInAnonymously(auth)
+      const u = cred.user
+      setUser(u)
+      const q = query(
+        collection(db, 'history'),
+        where('uid', '==', u.uid),
+        orderBy('ts', 'desc')
+      )
+      const snap = await getDocs(q)
+      const items = snap.docs.map(doc => doc.data())
+      setHistory(items)
+      setUsage(items.length)
+    }
+    signInAndLoad()
+  }, [])
 
   const runAnalysis = async () => {
+    if (usage >= usageLimit) {
+      alert('Free usage limit reached. Please upgrade to continue.')
+      return
+    }
     setLoading(true)
-    await signInAnonymously(auth)
     const res = await fetch('/api/analyze', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ prompt })
+      body: JSON.stringify({ prompt, model })
     })
     const data = await res.json()
     setResponse(data.result)
     setLoading(false)
-    await addDoc(collection(db, 'history'), { prompt, result: data.result, ts: Date.now() })
+    if (user) {
+      await addDoc(collection(db, 'history'), {
+        uid: user.uid,
+        prompt,
+        result: data.result,
+        ts: Date.now(),
+      })
+      setHistory([{ prompt, result: data.result, ts: Date.now() }, ...history])
+      setUsage(usage + 1)
+    }
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center p-4">
-      <h1 className="text-2xl font-bold mb-4">Nexus Cross AI</h1>
-      <textarea className="w-full p-2 border mb-2" value={prompt} onChange={(e) => setPrompt(e.target.value)} />
-      <button onClick={runAnalysis} className="bg-blue-500 text-white px-4 py-2" disabled={loading}>Run Analysis</button>
+    <main className="flex min-h-screen flex-col items-center p-4 space-y-4">
+      <h1 className="text-3xl font-bold">Nexus Cross AI</h1>
+      <div className="flex flex-col w-full max-w-xl space-y-2">
+        <select
+          className="border p-2"
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+        >
+          <option value="openai">OpenAI GPT-4o</option>
+          <option value="claude">Claude (soon)</option>
+          <option value="gemini">Gemini (soon)</option>
+        </select>
+        <textarea
+          className="w-full p-2 border"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+        />
+        <button
+          onClick={runAnalysis}
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+          disabled={loading}
+        >
+          Run Analysis
+        </button>
+        <p className="text-sm text-gray-600">Usage: {usage}/{usageLimit}</p>
+        {usage >= usageLimit && (
+          <p className="text-red-500">Free limit reached. <a href="#" className="underline">Upgrade to premium</a></p>
+        )}
+      </div>
       {loading && <p>Loading...</p>}
       {response && (
-        <div className="border-2 border-yellow-400 p-4 mt-4">
-          <p className="font-bold">Gold Result:</p>
+        <div className="border-2 border-yellow-400 p-4 mt-4 w-full max-w-xl">
+          <p className="font-bold mb-2">Result:</p>
           <p>{response}</p>
+        </div>
+      )}
+      {history.length > 0 && (
+        <div className="w-full max-w-xl mt-6">
+          <h2 className="text-xl font-semibold mb-2">History</h2>
+          <ul>
+            {history.map((h, i) => (
+              <li key={i} className="border p-2 mb-2">
+                <p className="font-semibold">{h.prompt}</p>
+                <p>{h.result}</p>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
     </main>


### PR DESCRIPTION
## Summary
- add dropdown to choose between models (only OpenAI works for now)
- save `uid` with history and show past prompts
- return placeholder text for other models in API route
- track usage count with upgrade message

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684438dd5cac8323ae0480e3649b1bf0