### PR TITLE
Implement landing screen and multi‑mode UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Nexus Cross AI
 
 This is a minimal prototype for the Nexus Cross AI project using Next.js, Firebase and multiple LLM APIs.
-The app features a freemium/premium toggle with usage limits and a dropdown to choose between AI models.
+The app features a freemium/premium toggle with usage limits and a dropdown to choose between AI modes.
 OpenAI, Claude and Gemini integrations are supported when the respective API keys are configured.
-Each authenticated user can see their request history stored in Firestore including the selected model and tier.
+Each authenticated user can see their request history stored in Firestore including the chosen mode and tier.
 
 ## Development
 
@@ -15,8 +15,10 @@ Each authenticated user can see their request history stored in Firestore includ
 npm run dev
 ```
 
-The app provides a simple textarea to submit a prompt. It calls a serverless
-function that forwards the prompt to GPT‑4 and shows a **Gold** styled result.
+The app now starts with a minimal landing screen. After clicking **Start Chat**
+users can submit prompts and select single, duo or trio AI modes. Requests are
+sent to the backend which orchestrates the chosen models and returns the
+result or a synthesized answer.
 Anonymous authentication is used and each interaction is stored in Firestore.
 
 Due to environment limitations this repository does not include `node_modules`.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,40 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.animate-fade-in {
+  animation: fade-in 0.5s ease-in-out;
+}
+
+@keyframes blink {
+  0%, 20% {
+    opacity: 0.2;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.2;
+  }
+}
+
+.loading-dots span {
+  animation: blink 1s infinite both;
+}
+
+.loading-dots span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.loading-dots span:nth-child(3) {
+  animation-delay: 0.4s;
+}


### PR DESCRIPTION
## Summary
- create landing screen and smooth fade animations
- add new loading dots indicator
- support gold/silver/bronze/duo/trio modes in API
- update frontend to allow selecting AI mode
- display individual and synthesized responses
- refresh README docs

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d17cb89c83239c63cd941c936efc